### PR TITLE
Throttle geo address requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bootstrap": "^3.3.4",
     "bootstrap-webpack": "0.0.5",
     "css-loader": "^0.23.1",
+    "debounce-promise": "^3.0.1",
     "events": "^1.0.2",
     "expect": "^1.13.4",
     "exports-loader": "^0.6.3",

--- a/subjects/RenderProps/utils/getAddressFromCoords.js
+++ b/subjects/RenderProps/utils/getAddressFromCoords.js
@@ -5,9 +5,12 @@ const GoogleMapsAPI = 'https://maps.googleapis.com/maps/api'
 const unthrottledGetAddressFromCoords = (latitude, longitude) => {
   const url = `${GoogleMapsAPI}/geocode/json?latlng=${latitude},${longitude}`
 
-  return fetch(url).then(res => res.json()).then(json => {
-    return json.results[0].formatted_address
-  })
+  return fetch(url)
+    .then(res => res.json())
+    .then(json => json.results[0].formatted_address)
+    .catch(error => {
+      throw error
+    })
 }
 
 // Throttle requests to once per second

--- a/subjects/RenderProps/utils/getAddressFromCoords.js
+++ b/subjects/RenderProps/utils/getAddressFromCoords.js
@@ -1,11 +1,16 @@
+import debounce from 'debounce-promise'
+
 const GoogleMapsAPI = 'https://maps.googleapis.com/maps/api'
 
-const getAddressFromCoords = (latitude, longitude) => {
+const unthrottledGetAddressFromCoords = (latitude, longitude) => {
   const url = `${GoogleMapsAPI}/geocode/json?latlng=${latitude},${longitude}`
 
   return fetch(url).then(res => res.json()).then(json => {
     return json.results[0].formatted_address
   })
 }
+
+// Throttle requests to once per second
+const getAddressFromCoords = debounce(unthrottledGetAddressFromCoords, 1000)
 
 export default getAddressFromCoords


### PR DESCRIPTION
Just one of many approaches.

It will limit requests to once per second, hopefully reducing the chance of any rate limiting from the Google api.