### PR TITLE
set initial checkbox to match with state

### DIFF
--- a/subjects/04 Forms/solution.js
+++ b/subjects/04 Forms/solution.js
@@ -91,6 +91,7 @@ class CheckoutForm extends React.Component {
             <label>
               <input
                 type="checkbox"
+                defaultChecked={shippingSameAsBilling}
                 onChange={event =>
                   this.setState({
                     shippingSameAsBilling: event.target.checked


### PR DESCRIPTION
Currently when updating CheckoutForm state shippingSameAsBilling state from false to true, the checkbox remains unchecked. This update allows for setting initial state of shippingSameAsBilling to true or false, rather than only false