### PR TITLE
Update to the new React Version 16.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,9 @@
   "author": "React Training LLC",
   "license": "GPL-3.0",
   "scripts": {
-    "start":
-      "node ./scripts/build.js && webpack-dev-server --inline --content-base public",
-    "ssr-exercise":
-      "supervisor -- -r babel-register 'subjects/13-Server-Rendering/exercise/server.js'",
-    "ssr-solution":
-      "supervisor -- -r babel-register 'subjects/13-Server-Rendering/solution/server.js'"
+    "start": "node ./scripts/build.js && webpack-dev-server --inline --content-base public",
+    "ssr-exercise": "supervisor -- -r babel-register 'subjects/13-Server-Rendering/exercise/server.js'",
+    "ssr-solution": "supervisor -- -r babel-register 'subjects/13-Server-Rendering/solution/server.js'"
   },
   "dependencies": {
     "angular": "1.5.8",
@@ -51,10 +48,10 @@
     "open-browser-webpack-plugin": "^0.0.5",
     "prop-types": "^15.5.10",
     "purecss": "0.6.0",
-    "react": "^16.4.1",
+    "react": "^16.6.0",
     "react-addons-css-transition-group": "^15.1.0",
     "react-addons-transition-group": "^15.1.0",
-    "react-dom": "^16.4.1",
+    "react-dom": "^16.6.0",
     "react-motion": "^0.4.2",
     "react-redux": "^5.0.2",
     "react-router-dom": "^4.0.0",


### PR DESCRIPTION
The new new context API is pretty nifty!

Looks like there may be some issues with this update and various package dependencies, like lecture 14 seems to now have issues. Looks like that may be from not using `create-react-app`, as the error is from `createReactClass`.

[Here's](https://stackoverflow.com/questions/46482433/reactjs-createclass-is-not-a-function) a potentially helpful link, sorry this update isn't flawless! Don't want to break Lecture 14 unexpectedly.

### Error from visiting Lecture 14

<img width="516" alt="screen shot 2018-10-24 at 3 20 06 pm" src="https://user-images.githubusercontent.com/15057490/47465110-4fe5ce80-d7a0-11e8-95d9-5cc852807133.png">
