### PR TITLE
CheckoutReview - Hide lonely comma's

### DIFF
--- a/apps/YesterTech/CheckoutReview.js
+++ b/apps/YesterTech/CheckoutReview.js
@@ -34,9 +34,11 @@ function CheckoutReview({ sameAsBilling, fields = {} }) {
           <br />
           <span>{fields.billingAddress}</span>
           <br />
-          <span>
-            {fields.billingCity}, {fields.billingState} {fields.billingPostal}
-          </span>
+          {fields.billingCity && (
+            <span>
+              {fields.billingCity}, {fields.billingState} {fields.billingPostal}
+            </span>
+          )}
         </Column>
         <Column className="spacing-small" flex>
           <Heading as="h2" size={4}>
@@ -50,9 +52,11 @@ function CheckoutReview({ sameAsBilling, fields = {} }) {
               <br />
               <span>{fields.shippingAddress}</span>
               <br />
-              <span>
-                {fields.shippingCity}, {fields.shippingState} {fields.shippingPostal}
-              </span>
+              {fields.shippingCity && (
+                <span>
+                  {fields.shippingCity}, {fields.shippingState} {fields.shippingPostal}
+                </span>
+              )}
             </Fragment>
           )}
         </Column>


### PR DESCRIPTION
Conditionally show the city state and billing postal in CheckoutReview to hide the lonely comma's when the workshop only utilizes name and address fields. 

![image](https://user-images.githubusercontent.com/8321838/75580544-f6e21680-5a35-11ea-879c-00dc0dc4401f.png)
